### PR TITLE
Mitigate CVE-2021-44228

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     curl -L https://dlcdn.apache.org/hive/hive-2.3.9/apache-hive-2.3.9-bin.tar.gz | tar zxf - && \
     curl -L https://dlcdn.apache.org/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz | tar zxf - && \
     apt-get install --only-upgrade openssl libssl1.1 && \
-    apt-get install -y libk5crypto3 libkrb5-3 libsqlite3-0
+    apt-get install -y libk5crypto3 libkrb5-3 libsqlite3-0 zip
 
 RUN rm ${HIVE_HOME}/lib/postgresql-9.4.1208.jre7.jar
 
@@ -24,6 +24,8 @@ COPY conf ${HIVE_HOME}/conf
 RUN groupadd -r hive --gid=1000 && \
     useradd -r -g hive --uid=1000 -d ${HIVE_HOME} hive && \
     chown hive:hive -R ${HIVE_HOME}
+
+RUN zip -q -d /opt/hive/lib/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 USER hive
 WORKDIR $HIVE_HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN groupadd -r hive --gid=1000 && \
     useradd -r -g hive --uid=1000 -d ${HIVE_HOME} hive && \
     chown hive:hive -R ${HIVE_HOME}
 
-RUN zip -q -d /opt/hive/lib/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+RUN zip -q -d /opt/apache-hive-*-bin/lib/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 USER hive
 WORKDIR $HIVE_HOME


### PR DESCRIPTION
As suggested in https://nvd.nist.gov/vuln/detail/CVE-2021-44228 we add
line 28 in the Dockerfile to remove `JndiLookup.class` from Log4J classpath.