### PR TITLE
Bump Log4j from 2.19.0 to 2.20.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV HADOOP_HOME=/opt/hadoop
 ENV HADOOP_VERSION=3.3.4
 ENV HIVE_HOME=/opt/hive
 ENV HIVE_VERSION=3.1.3
-ENV LOG4J_VERSION=2.19.0
+ENV LOG4J_VERSION=2.20.0
 ENV LOG4J_LOCATION="https://repo1.maven.org/maven2/org/apache/logging/log4j"
 
 RUN mkdir ${HIVE_HOME}

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -3,7 +3,7 @@ commandTests:
 - name: jre
   command: java
   args: ["-version"]
-  expectedError: ['openjdk version "17.0.4"*']
+  expectedError: ['openjdk version "17.0.6"*']
 - name: openssl
   command: apt
   args: ["list", "openssl"]

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -29,7 +29,7 @@ fileExistenceTests:
 metadataTest:
   env:
   - key: JAVA_HOME
-    value: /usr/lib/jvm/zulu17-ca-amd64
+    value: /usr/lib/jvm/zulu17
   - key: HADOOP_HOME
     value: /opt/hadoop
   - key: HIVE_HOME


### PR DESCRIPTION
Supports https://github.ibm.com/whitewater-analytics/discuss/issues/3022